### PR TITLE
Placeholderの表示・非表示だけの機能を実装

### DIFF
--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -54,7 +54,7 @@ final class CustomTextView: UITextView {
         //        placeholderLabel.textAlignment = .center
         placeholderLabel.sizeToFit()
         
-        self.addSubview(placeholderLabel)
+        addSubview(placeholderLabel)
         //        self.sendSubview(toBack: placeholderLabel)
         print("Add placeholderLabel as subView")
     }

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -16,7 +16,7 @@ final class CustomTextView: UITextView {
     @IBInspectable var placeholder: String? {
         didSet {
             print("placeholder did set.")
-            drawPlaceholder(in: frame)
+//            drawPlaceholder(in: frame)
         }
     }
     
@@ -34,8 +34,8 @@ final class CustomTextView: UITextView {
     
     init(frame: CGRect) {
         super.init(frame: frame, textContainer: nil)
-        initialize()
-        drawPlaceholder(in: frame)
+        observeTextDidChange()
+        configurePlaceholder(in: frame)
     }
     
     private func observeTextDidChange() {
@@ -43,7 +43,7 @@ final class CustomTextView: UITextView {
         NotificationCenter.default.addObserver(self, selector: #selector(controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
     }
     
-    func drawPlaceholder(in rect: CGRect) {
+    private func configurePlaceholder(in rect: CGRect) {
         placeholderLabel.frame = rect
         //        placeholderLabel.frame.origin = CGPoint.zero
         placeholderLabel.text = placeholder

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -9,14 +9,65 @@
 import UIKit
 
 class CustomTextView: UITextView {
+    private let placeholderLabel: UILabel = UILabel()
     
+    // default is nil. string is drawn 70% gray
+    var placeholder: String? {
+        didSet {
+            print("placeholder did set.")
+            drawPlaceholder(in: self.frame)
+        }
+    }
     
-    /*
+    func drawPlaceholder(in rect: CGRect) {
+        // 通知を登録する
+        NotificationCenter.default.addObserver(self, selector: #selector(CustomTextView.controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
+    }
+    
+    //  TextViewのTextが変更された時に呼ばれる
+    func controlPlaceholder(_ notification: NSNotification) {
+        print("UITextViewTextDidChange!")
+        placeholderIsHidden()
+        
+    }
+    
+    private func placeholderIsHidden() {
+        if text.isEmpty {
+            placeholderLabel.isHidden = false
+        } else {
+            placeholderLabel.isHidden = true
+        }
+    }
+    
+    override var text: String! {
+        didSet {
+            print("didiSet: " + text)
+            placeholderIsHidden()
+        }
+    }
+    
+    override var textAlignment: NSTextAlignment {
+        didSet {
+            print("didiSet: \(textAlignment)")
+        }
+    }
+    
     // Only override draw() if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.
     override func draw(_ rect: CGRect) {
-        // Drawing code
+        super.draw(rect)
+        
+        placeholderLabel.frame = rect
+        placeholderLabel.text = placeholder
+        placeholderLabel.font = self.font
+        placeholderLabel.backgroundColor = UIColor.clear
+        placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
+        placeholderLabel.textAlignment = self.textAlignment
+        placeholderLabel.sizeToFit()
+        
+        self.addSubview(placeholderLabel)
+        self.sendSubview(toBack: placeholderLabel)
+        print("Add placeholderLabel as subView")
     }
-    */
 
 }

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -54,7 +54,7 @@ final class CustomTextView: UITextView {
     // Placeholerの初期化設定(1回のみ)
     private func configurePlaceholder() {
         placeholderLabel.frame = frame
-        self.textContainerInset = UIEdgeInsetsMake(5, 5, 5, 5)
+        self.textContainerInset = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
         placeholderLabel.frame.origin = CGPoint(x: 8, y: 5)
         // default is clear
         placeholderLabel.backgroundColor = UIColor.blue.withAlphaComponent(0.5)

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -60,18 +60,13 @@ class CustomTextView: UITextView {
     }
     
     //  TextViewのTextが変更された時に呼ばれる
-    func controlPlaceholder(_ notification: NSNotification) {
-        print("UITextViewTextDidChange!")
+    @objc private func controlPlaceholder(_ notification: NSNotification) {
+        print("Notification->UITextViewTextDidChange!")
         placeholderIsHidden()
-        
     }
     
     private func placeholderIsHidden() {
-        if text.isEmpty {
-            placeholderLabel.isHidden = false
-        } else {
-            placeholderLabel.isHidden = true
-        }
+        placeholderLabel.isHidden = !text.isEmpty
     }
     
     override var text: String! {
@@ -84,25 +79,26 @@ class CustomTextView: UITextView {
     override var textAlignment: NSTextAlignment {
         didSet {
             print("didiSet: \(textAlignment)")
+            placeholderLabel.textAlignment = self.textAlignment
         }
     }
     
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        super.draw(rect)
-        
-        placeholderLabel.frame = rect
-        placeholderLabel.text = placeholder
-        placeholderLabel.font = self.font
-        placeholderLabel.backgroundColor = UIColor.clear
-        placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
-        placeholderLabel.textAlignment = self.textAlignment
-        placeholderLabel.sizeToFit()
-        
-        self.addSubview(placeholderLabel)
-        self.sendSubview(toBack: placeholderLabel)
-        print("Add placeholderLabel as subView")
-    }
+//    // Only override draw() if you perform custom drawing.
+//    // An empty implementation adversely affects performance during animation.
+//    override func draw(_ rect: CGRect) {
+//        super.draw(rect)
+//        
+//        placeholderLabel.frame = rect
+//        placeholderLabel.text = placeholder
+//        placeholderLabel.font = self.font
+//        placeholderLabel.backgroundColor = UIColor.clear
+//        placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
+//        placeholderLabel.textAlignment = self.textAlignment
+//        placeholderLabel.sizeToFit()
+//        
+//        self.addSubview(placeholderLabel)
+//        self.sendSubview(toBack: placeholderLabel)
+//        print("Add placeholderLabel as subView")
+//    }
 
 }

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -9,19 +9,19 @@
 import UIKit
 
 class CustomTextView: UITextView {
-    private let placeholderLabel: UILabel = UILabel()
+    private let placeholderLabel = UILabel()
     
     // default is nil. string is drawn 70% gray
     var placeholder: String? {
         didSet {
             print("placeholder did set.")
-            drawPlaceholder(in: self.frame)
+            drawPlaceholder(in: frame)
         }
     }
     
     func drawPlaceholder(in rect: CGRect) {
         // 通知を登録する
-        NotificationCenter.default.addObserver(self, selector: #selector(CustomTextView.controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
     }
     
     //  TextViewのTextが変更された時に呼ばれる

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -8,11 +8,12 @@
 
 import UIKit
 
+@IBDesignable
 class CustomTextView: UITextView {
     private let placeholderLabel = UILabel()
     
     // default is nil. string is drawn 70% gray
-    var placeholder: String? {
+    @IBInspectable var placeholder: String? {
         didSet {
             print("placeholder did set.")
             drawPlaceholder(in: frame)

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -19,18 +19,13 @@ final class CustomTextView: UITextView {
     @IBInspectable var placeholder: String? {
         didSet {
             print("placeholder did set.")
+            placeholderLabel.text = placeholder
+            placeholderLabel.sizeToFit()
         }
     }
     
+    
     // MARK: - initializers
-    
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
     
     init() {
         super.init(frame: .null, textContainer: nil)
@@ -39,7 +34,15 @@ final class CustomTextView: UITextView {
     init(frame: CGRect) {
         super.init(frame: frame, textContainer: nil)
         observeTextDidChange()
-        configurePlaceholder(in: frame)
+        initPlaceholder()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     
@@ -50,19 +53,22 @@ final class CustomTextView: UITextView {
         NotificationCenter.default.addObserver(self, selector: #selector(controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
     }
     
-    private func configurePlaceholder(in rect: CGRect) {
-        placeholderLabel.frame = rect
-//        placeholderLabel.frame.origin = CGPoint.zero
-        placeholderLabel.text = placeholder
-        placeholderLabel.font = font
+    // Placeholerの初期化設定(1回のみ)
+    private func initPlaceholder() {
+        placeholderLabel.frame = frame
+        self.textContainerInset = UIEdgeInsetsMake(5, 5, 5, 5)
+        placeholderLabel.frame.origin = CGPoint(x: 8, y: 5)
+        // default is clear
         placeholderLabel.backgroundColor = UIColor.blue.withAlphaComponent(0.5)
+        // default is 70% gray
         placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
-        placeholderLabel.textAlignment = textAlignment
-//        placeholderLabel.textAlignment = .center
-        placeholderLabel.sizeToFit()
         
-        addSubview(placeholderLabel)
-//        self.sendSubview(toBack: placeholderLabel)
+        placeholderLabel.font = font
+        print(placeholderLabel.font.pointSize)
+        placeholderLabel.textAlignment = textAlignment
+        
+        self.addSubview(placeholderLabel)
+        //        self.sendSubview(toBack: placeholderLabel)
         print("Add placeholderLabel as subView")
     }
     
@@ -89,7 +95,14 @@ final class CustomTextView: UITextView {
     override var textAlignment: NSTextAlignment {
         didSet {
             print("didiSet: \(textAlignment)")
-            placeholderLabel.textAlignment = self.textAlignment
+            placeholderLabel.textAlignment = textAlignment
+        }
+    }
+    
+    override var font: UIFont? {
+        didSet {
+            print("didiSet: \(font)")
+            placeholderLabel.font = font
         }
     }
     

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -16,7 +16,6 @@ final class CustomTextView: UITextView {
     @IBInspectable var placeholder: String? {
         didSet {
             print("placeholder did set.")
-//            drawPlaceholder(in: frame)
         }
     }
     
@@ -45,17 +44,17 @@ final class CustomTextView: UITextView {
     
     private func configurePlaceholder(in rect: CGRect) {
         placeholderLabel.frame = rect
-        //        placeholderLabel.frame.origin = CGPoint.zero
+//        placeholderLabel.frame.origin = CGPoint.zero
         placeholderLabel.text = placeholder
         placeholderLabel.font = self.font
         placeholderLabel.backgroundColor = UIColor.blue.withAlphaComponent(0.5)
         placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
         placeholderLabel.textAlignment = self.textAlignment
-        //        placeholderLabel.textAlignment = .center
+//        placeholderLabel.textAlignment = .center
         placeholderLabel.sizeToFit()
         
         addSubview(placeholderLabel)
-        //        self.sendSubview(toBack: placeholderLabel)
+//        self.sendSubview(toBack: placeholderLabel)
         print("Add placeholderLabel as subView")
     }
     
@@ -83,22 +82,12 @@ final class CustomTextView: UITextView {
         }
     }
     
-//    // Only override draw() if you perform custom drawing.
-//    // An empty implementation adversely affects performance during animation.
-//    override func draw(_ rect: CGRect) {
-//        super.draw(rect)
-//        
-//        placeholderLabel.frame = rect
-//        placeholderLabel.text = placeholder
-//        placeholderLabel.font = self.font
-//        placeholderLabel.backgroundColor = UIColor.clear
-//        placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
-//        placeholderLabel.textAlignment = self.textAlignment
-//        placeholderLabel.sizeToFit()
-//        
-//        self.addSubview(placeholderLabel)
-//        self.sendSubview(toBack: placeholderLabel)
-//        print("Add placeholderLabel as subView")
-//    }
+    /*
+     // Only override draw() if you perform custom drawing.
+     // An empty implementation adversely affects performance during animation.
+     override func draw(_ rect: CGRect) {
+     // Drawing code
+     }
+     */
 
 }

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -27,10 +27,6 @@ final class CustomTextView: UITextView {
     
     // MARK: - initializers
     
-    init() {
-        super.init(frame: .null, textContainer: nil)
-    }
-    
     init(frame: CGRect) {
         super.init(frame: frame, textContainer: nil)
         observeTextDidChange()

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -20,9 +20,43 @@ class CustomTextView: UITextView {
         }
     }
     
-    func drawPlaceholder(in rect: CGRect) {
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+//    override init() {
+//        super.init()
+//    }
+    
+    init(frame: CGRect) {
+        super.init(frame: frame, textContainer: nil)
+        initialize()
+        drawPlaceholder(in: frame)
+    }
+    
+    private func initialize() {
         // 通知を登録する
         NotificationCenter.default.addObserver(self, selector: #selector(controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
+    }
+    
+    func drawPlaceholder(in rect: CGRect) {
+        placeholderLabel.frame = rect
+        //        placeholderLabel.frame.origin = CGPoint.zero
+        placeholderLabel.text = placeholder
+        placeholderLabel.font = self.font
+        placeholderLabel.backgroundColor = UIColor.blue.withAlphaComponent(0.5)
+        placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
+        placeholderLabel.textAlignment = self.textAlignment
+        //        placeholderLabel.textAlignment = .center
+        placeholderLabel.sizeToFit()
+        
+        self.addSubview(placeholderLabel)
+        //        self.sendSubview(toBack: placeholderLabel)
+        print("Add placeholderLabel as subView")
     }
     
     //  TextViewのTextが変更された時に呼ばれる

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @IBDesignable
-class CustomTextView: UITextView {
+final class CustomTextView: UITextView {
     private let placeholderLabel = UILabel()
     
     // default is nil. string is drawn 70% gray

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -38,7 +38,7 @@ final class CustomTextView: UITextView {
         drawPlaceholder(in: frame)
     }
     
-    private func initialize() {
+    private func observeTextDidChange() {
         // 通知を登録する
         NotificationCenter.default.addObserver(self, selector: #selector(controlPlaceholder(_:)), name: .UITextViewTextDidChange, object: nil)
     }

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -35,6 +35,8 @@ final class CustomTextView: UITextView {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        observeTextDidChange()
+        configurePlaceholder()
     }
     
     deinit {

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -10,6 +10,9 @@ import UIKit
 
 @IBDesignable
 final class CustomTextView: UITextView {
+    
+    // MARK: - placeholer
+    
     private let placeholderLabel = UILabel()
     
     // default is nil. string is drawn 70% gray
@@ -18,6 +21,8 @@ final class CustomTextView: UITextView {
             print("placeholder did set.")
         }
     }
+    
+    // MARK: - initializers
     
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -36,6 +41,9 @@ final class CustomTextView: UITextView {
         observeTextDidChange()
         configurePlaceholder(in: frame)
     }
+    
+    
+    // MARK: - private methods
     
     private func observeTextDidChange() {
         // 通知を登録する
@@ -67,6 +75,9 @@ final class CustomTextView: UITextView {
     private func placeholderIsHidden() {
         placeholderLabel.isHidden = !text.isEmpty
     }
+    
+    
+    // MARK: - override properties
     
     override var text: String! {
         didSet {

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -30,7 +30,7 @@ final class CustomTextView: UITextView {
     init(frame: CGRect) {
         super.init(frame: frame, textContainer: nil)
         observeTextDidChange()
-        initPlaceholder()
+        configurePlaceholder()
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -50,7 +50,7 @@ final class CustomTextView: UITextView {
     }
     
     // Placeholerの初期化設定(1回のみ)
-    private func initPlaceholder() {
+    private func configurePlaceholder() {
         placeholderLabel.frame = frame
         self.textContainerInset = UIEdgeInsetsMake(5, 5, 5, 5)
         placeholderLabel.frame.origin = CGPoint(x: 8, y: 5)

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -46,10 +46,10 @@ final class CustomTextView: UITextView {
         placeholderLabel.frame = rect
 //        placeholderLabel.frame.origin = CGPoint.zero
         placeholderLabel.text = placeholder
-        placeholderLabel.font = self.font
+        placeholderLabel.font = font
         placeholderLabel.backgroundColor = UIColor.blue.withAlphaComponent(0.5)
         placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)
-        placeholderLabel.textAlignment = self.textAlignment
+        placeholderLabel.textAlignment = textAlignment
 //        placeholderLabel.textAlignment = .center
         placeholderLabel.sizeToFit()
         

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -25,12 +25,12 @@ final class CustomTextView: UITextView {
     }
     
     required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
-//    override init() {
-//        super.init()
-//    }
+    init() {
+        super.init(frame: .null, textContainer: nil)
+    }
     
     init(frame: CGRect) {
         super.init(frame: frame, textContainer: nil)

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -9,17 +9,70 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    var textView: CustomTextView = CustomTextView()
+    var textField: UITextField = UITextField()
+    
+    var width: CGFloat = 200
+    var textViewHeight: CGFloat = 100
+    var textFieldhHeight: CGFloat = 50
+    var buttonHeight: CGFloat = 50
+    var posX: CGFloat { return self.view.frame.width / 2}
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+        
+        configTextView()
+        configTextField()
+        configButton()
+        
     }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    
+    func configTextView() {
+        textView.frame.size = CGSize(width: width, height: textViewHeight)
+        textView.layer.position = CGPoint(x: posX, y: 100)
+        textView.text = "Fist text"
+        textView.placeholder = "Placeholder"
+        
+        self.view.addSubview(textView)
     }
-
+    
+    func configTextField() {
+        textField.frame.size = CGSize(width: width, height: textFieldhHeight)
+        textField.layer.position = CGPoint(x: posX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
+        textField.text = "Fist text"
+        textField.placeholder = "Placeholder"
+        textField.borderStyle = .line
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.textFieldTextDidChanged(_:)), name: .UITextFieldTextDidChange, object: nil)
+        
+        self.view.addSubview(textField)
+    }
+    
+    func textFieldTextDidChanged(_ notification: NSNotification) {
+        print("UITextFieldTextDidChange!")
+    }
+    
+    func configButton() {
+        let button = UIButton(type: .system)
+        button.frame.size = CGSize(width: width, height: buttonHeight)
+        button.layer.position = CGPoint(x: posX, y: textField.layer.position.y + textFieldhHeight / 2 + buttonHeight / 2)
+        button.setTitle("Button", for: .normal)
+        button.setTitleColor(UIColor.red, for: .normal)
+        button.setTitle("Pushed", for: .highlighted)
+        button.setTitleColor(UIColor.blue, for: .highlighted)
+        button.addTarget(self, action: #selector(ViewController.tapButton(_:)), for: .touchUpInside)
+        
+        self.view.addSubview(button)
+    }
+    
+    func tapButton(_ sender: UIButton) {
+        print("TapButton!")
+        textView.text = textView.text + "+addText"
+        //        textView.textAlignment = .center
+        textField.text = textField.text! + "+addText"
+    }
 
 }
 

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    var textView = CustomTextView()
-    var textField = UITextField()
+    var textView: CustomTextView!
+    var textField: UITextField!
     
     let width: CGFloat = 200
     let textViewHeight: CGFloat = 100

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -36,7 +36,7 @@ class ViewController: UIViewController {
         textView.placeholder = "Placeholder"
         textView.delegate = self
         
-        self.view.addSubview(textView)
+        view.addSubview(textView)
     }
     
     func configTextField() {
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldTextDidChanged(_:)), name: .UITextFieldTextDidChange, object: nil)
         
-        self.view.addSubview(textField)
+        view.addSubview(textField)
     }
     
     func textFieldTextDidChanged(_ notification: NSNotification) {
@@ -66,7 +66,7 @@ class ViewController: UIViewController {
         button.setTitleColor(UIColor.blue, for: .highlighted)
         button.addTarget(self, action: #selector(ViewController.tapButton(_:)), for: .touchUpInside)
         
-        self.view.addSubview(button)
+        view.addSubview(button)
     }
     
     func tapButton(_ sender: UIButton) {

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -10,14 +10,14 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    var textView: CustomTextView!
-    var textField: UITextField!
+    private var textView = CustomTextView(frame: CGRect.zero)
+    private var textField = UITextField(frame: CGRect.zero)
     
-    let width: CGFloat = 200
-    let textViewHeight: CGFloat = 100
-    let textFieldhHeight: CGFloat = 50
-    let buttonHeight: CGFloat = 50
-    var centerPositionX: CGFloat { return self.view.frame.width / 2}
+    private let width: CGFloat = 200
+    private let textViewHeight: CGFloat = 100
+    private let textFieldhHeight: CGFloat = 50
+    private let buttonHeight: CGFloat = 50
+    private var centerPositionX: CGFloat { return self.view.frame.width / 2}
     
     
     override func viewDidLoad() {
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
         
     }
     
-    func configureTextView() {
+    private func configureTextView() {
         textView.frame.size = CGSize(width: width, height: textViewHeight)
         textView.layer.position = CGPoint(x: centerPositionX, y: 100)
         textView.text = "Fist text"
@@ -39,7 +39,7 @@ class ViewController: UIViewController {
         view.addSubview(textView)
     }
     
-    func configureTextField() {
+    private func configureTextField() {
         textField.frame.size = CGSize(width: width, height: textFieldhHeight)
         textField.layer.position = CGPoint(x: centerPositionX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
         textField.text = "Fist text"
@@ -52,11 +52,11 @@ class ViewController: UIViewController {
         view.addSubview(textField)
     }
     
-    func textFieldTextDidChanged(_ notification: NSNotification) {
+    @objc private func textFieldTextDidChanged(_ notification: NSNotification) {
         print("Notification->UITextFieldTextDidChange!")
     }
     
-    func configureButton() {
+    private func configureButton() {
         let button = UIButton(type: .system)
         button.frame.size = CGSize(width: width, height: buttonHeight)
         button.layer.position = CGPoint(x: centerPositionX, y: textField.layer.position.y + textFieldhHeight / 2 + buttonHeight / 2)
@@ -69,10 +69,9 @@ class ViewController: UIViewController {
         view.addSubview(button)
     }
     
-    func tapButton(_ sender: UIButton) {
+    @objc private func tapButton(_ sender: UIButton) {
         print("TapButton!")
         textView.text = textView.text + "+addText"
-//        textView.textAlignment = .center
         textField.text = textField.text ?? "" + "+addText"
     }
 

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -64,7 +64,7 @@ class ViewController: UIViewController {
         button.setTitleColor(UIColor.red, for: .normal)
         button.setTitle("Pushed", for: .highlighted)
         button.setTitleColor(UIColor.blue, for: .highlighted)
-        button.addTarget(self, action: #selector(ViewController.tapButton(_:)), for: .touchUpInside)
+        button.addTarget(self, action: #selector(tapButton(_:)), for: .touchUpInside)
         
         view.addSubview(button)
     }

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -13,10 +13,10 @@ class ViewController: UIViewController {
     var textView = CustomTextView()
     var textField = UITextField()
     
-    var width: CGFloat = 200
-    var textViewHeight: CGFloat = 100
-    var textFieldhHeight: CGFloat = 50
-    var buttonHeight: CGFloat = 50
+    let width: CGFloat = 200
+    let textViewHeight: CGFloat = 100
+    let textFieldhHeight: CGFloat = 50
+    let buttonHeight: CGFloat = 50
     var posX: CGFloat { return self.view.frame.width / 2}
     
     
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
     }
     
     func textFieldTextDidChanged(_ notification: NSNotification) {
-        print("UITextFieldTextDidChange!")
+        print("Notification->UITextFieldTextDidChange!")
     }
     
     func configButton() {
@@ -72,7 +72,7 @@ class ViewController: UIViewController {
     func tapButton(_ sender: UIButton) {
         print("TapButton!")
         textView.text = textView.text + "+addText"
-        //        textView.textAlignment = .center
+//        textView.textAlignment = .center
         textField.text = textField.text! + "+addText"
     }
 

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    private var textView = CustomTextView(frame: CGRect.zero)
-    private var textField = UITextField(frame: CGRect.zero)
+    private var textView = CustomTextView(frame: .zero)
+    private var textField = UITextField(frame: .zero)
     
     private let width: CGFloat = 200
     private let textViewHeight: CGFloat = 100

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -73,7 +73,7 @@ class ViewController: UIViewController {
         print("TapButton!")
         textView.text = textView.text + "+addText"
 //        textView.textAlignment = .center
-        textField.text = textField.text! + "+addText"
+        textField.text = textField.text ?? "" + "+addText"
     }
 
 }

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    var textView: CustomTextView = CustomTextView()
-    var textField: UITextField = UITextField()
+    var textView = CustomTextView()
+    var textField = UITextField()
     
     var width: CGFloat = 200
     var textViewHeight: CGFloat = 100
@@ -45,7 +45,7 @@ class ViewController: UIViewController {
         textField.placeholder = "Placeholder"
         textField.borderStyle = .line
         
-        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.textFieldTextDidChanged(_:)), name: .UITextFieldTextDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(textFieldTextDidChanged(_:)), name: .UITextFieldTextDidChange, object: nil)
         
         self.view.addSubview(textField)
     }

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -42,7 +42,10 @@ class ViewController: UIViewController {
     private func configureTextField() {
         textField.frame.size = CGSize(width: width, height: textFieldhHeight)
         textField.layer.position = CGPoint(x: centerPositionX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
+        textView.layer.borderColor = UIColor.black.cgColor
+        textView.layer.borderWidth = 1
         textField.text = "Fist text"
+        textView.font = .systemFont(ofSize: 22.0)
         textField.placeholder = "Placeholder"
         textField.borderStyle = .line
         textField.delegate = self

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
     
     private func configureTextView() {
         textView.frame.size = CGSize(width: width, height: textViewHeight)
-        textView.layer.position = CGPoint(x: centerPositionX, y: 100)
+        textView.frame.origin = CGPoint(x: centerPositionX - width / 2, y: 100)
         textView.text = "Fist text"
         textView.placeholder = "Placeholder"
         textView.delegate = self
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
     
     private func configureTextField() {
         textField.frame.size = CGSize(width: width, height: textFieldhHeight)
-        textField.layer.position = CGPoint(x: centerPositionX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
+        textField.frame.origin = CGPoint(x: centerPositionX - width / 2, y: textView.frame.origin.y + textViewHeight)
         textView.layer.borderColor = UIColor.black.cgColor
         textView.layer.borderWidth = 1
         textField.text = "Fist text"
@@ -60,9 +60,9 @@ class ViewController: UIViewController {
     }
     
     private func configureButton() {
-        let button = UIButton(type: .system)
-        button.frame.size = CGSize(width: width, height: buttonHeight)
-        button.layer.position = CGPoint(x: centerPositionX, y: textField.layer.position.y + textFieldhHeight / 2 + buttonHeight / 2)
+        let size = CGSize(width: width, height: buttonHeight)
+        let point = CGPoint(x: centerPositionX - width / 2, y: textField.frame.origin.y + textFieldhHeight)
+        let button = UIButton(frame: CGRect(origin: point, size: size))
         button.setTitle("Button", for: .normal)
         button.setTitleColor(UIColor.red, for: .normal)
         button.setTitle("Pushed", for: .highlighted)

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -34,6 +34,7 @@ class ViewController: UIViewController {
         textView.layer.position = CGPoint(x: posX, y: 100)
         textView.text = "Fist text"
         textView.placeholder = "Placeholder"
+        textView.delegate = self
         
         self.view.addSubview(textView)
     }
@@ -44,6 +45,7 @@ class ViewController: UIViewController {
         textField.text = "Fist text"
         textField.placeholder = "Placeholder"
         textField.borderStyle = .line
+        textField.delegate = self
         
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldTextDidChanged(_:)), name: .UITextFieldTextDidChange, object: nil)
         
@@ -75,4 +77,29 @@ class ViewController: UIViewController {
     }
 
 }
+
+
+extension ViewController: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+}
+
+
+extension ViewController: UITextViewDelegate {
+    
+    func textViewDidChange(_ textView: UITextView) {
+        print("Delegate->textViewDidChange")
+    }
+    
+}
+
+
+
+
+
+
 

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UIViewController {
     let textViewHeight: CGFloat = 100
     let textFieldhHeight: CGFloat = 50
     let buttonHeight: CGFloat = 50
-    var posX: CGFloat { return self.view.frame.width / 2}
+    var centerPositionX: CGFloat { return self.view.frame.width / 2}
     
     
     override func viewDidLoad() {
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
     
     func configTextField() {
         textField.frame.size = CGSize(width: width, height: textFieldhHeight)
-        textField.layer.position = CGPoint(x: posX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
+        textField.layer.position = CGPoint(x: centerPositionX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
         textField.text = "Fist text"
         textField.placeholder = "Placeholder"
         textField.borderStyle = .line
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
     func configButton() {
         let button = UIButton(type: .system)
         button.frame.size = CGSize(width: width, height: buttonHeight)
-        button.layer.position = CGPoint(x: posX, y: textField.layer.position.y + textFieldhHeight / 2 + buttonHeight / 2)
+        button.layer.position = CGPoint(x: centerPositionX, y: textField.layer.position.y + textFieldhHeight / 2 + buttonHeight / 2)
         button.setTitle("Button", for: .normal)
         button.setTitleColor(UIColor.red, for: .normal)
         button.setTitle("Pushed", for: .highlighted)

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -23,15 +23,15 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        configTextView()
-        configTextField()
-        configButton()
+        configureTextView()
+        configureTextField()
+        configureButton()
         
     }
     
-    func configTextView() {
+    func configureTextView() {
         textView.frame.size = CGSize(width: width, height: textViewHeight)
-        textView.layer.position = CGPoint(x: posX, y: 100)
+        textView.layer.position = CGPoint(x: centerPositionX, y: 100)
         textView.text = "Fist text"
         textView.placeholder = "Placeholder"
         textView.delegate = self
@@ -39,7 +39,7 @@ class ViewController: UIViewController {
         view.addSubview(textView)
     }
     
-    func configTextField() {
+    func configureTextField() {
         textField.frame.size = CGSize(width: width, height: textFieldhHeight)
         textField.layer.position = CGPoint(x: centerPositionX, y: 100 + textViewHeight / 2 + textViewHeight / 2)
         textField.text = "Fist text"
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
         print("Notification->UITextFieldTextDidChange!")
     }
     
-    func configButton() {
+    func configureButton() {
         let button = UIButton(type: .system)
         button.frame.size = CGSize(width: width, height: buttonHeight)
         button.layer.position = CGPoint(x: centerPositionX, y: textField.layer.position.y + textFieldhHeight / 2 + buttonHeight / 2)


### PR DESCRIPTION
`Label`を使って`placeholder`の表示・非表示の挙動を`TextField`と同等になるように実装しました。

`NSNotification`を使って`UITextViewTextDidChange`の時に`Label`の表示・非表示を決めるメソッド`placeholderIsHidden()`を呼び出します。
これだと、`Button タップ`時のメソッド内で`text`を変更した場合などには呼び出されませんでした。

一方、`var text`の`didSet{}`内で`placeholderIsHidden()`を呼び出すようにすると、`TextVIew`内のテキストをAll Deleteした場合などには呼び出されませんでした。

なのでとりあえず、この2つを併用することで見かけ上は`TextField`と同じ挙動になっていると思います。
これだと処理の重複が起こりまくってますが、、、
