### PR TITLE
#22 textContainerInset変更時のplaceholderのレイアウト

### DIFF
--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -81,6 +81,15 @@ final class CustomTextView: UITextView {
         didSet {
             print("didiSet: \(textContainerInset)")
             placeholderLabel.frame.origin = CGPoint(x: textContainerInset.left + paddingLeft, y: textContainerInset.top)
+            
+            if oldValue.left != textContainerInset.left {
+                placeholderLabel.frame.size.width = placeholderLabel.frame.width + oldValue.left - textContainerInset.left
+            }
+            
+            if oldValue.right != textContainerInset.right {
+                placeholderLabel.frame.size.width = placeholderLabel.frame.width + oldValue.right - textContainerInset.right
+            }
+            
 //            placeholderLabel.frame.size = CGSize(width: textContainer.size.width - paddingLeft * 2, height: textContainer.size.height)
         }
     }
@@ -166,7 +175,7 @@ private extension CustomTextView {
     // Placeholerの初期化設定
     func configurePlaceholder() {
         // default is clear
-        //        placeholderLabel.backgroundColor = UIColor.clear
+//        placeholderLabel.backgroundColor = UIColor.clear
         placeholderLabel.backgroundColor = UIColor.blue.withAlphaComponent(0.5)
         // default is 70% gray
         placeholderLabel.textColor = UIColor.gray.withAlphaComponent(0.7)

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -82,15 +82,16 @@ final class CustomTextView: UITextView {
             print("didiSet: \(textContainerInset)")
             placeholderLabel.frame.origin = CGPoint(x: textContainerInset.left + paddingLeft, y: textContainerInset.top)
             
-            if oldValue.left != textContainerInset.left {
-                placeholderLabel.frame.size.width = placeholderLabel.frame.width + oldValue.left - textContainerInset.left
-            }
+//            if oldValue.left != textContainerInset.left {
+//                placeholderLabel.frame.size.width = placeholderLabel.frame.width + oldValue.left - textContainerInset.left
+//            }
+//            
+//            if oldValue.right != textContainerInset.right {
+//                placeholderLabel.frame.size.width = placeholderLabel.frame.width + oldValue.right - textContainerInset.right
+//            }
             
-            if oldValue.right != textContainerInset.right {
-                placeholderLabel.frame.size.width = placeholderLabel.frame.width + oldValue.right - textContainerInset.right
-            }
+            placeholderLabel.frame.size.width = placeholderLabel.frame.width + (oldValue.left - textContainerInset.left) + (oldValue.right - textContainerInset.right)
             
-//            placeholderLabel.frame.size = CGSize(width: textContainer.size.width - paddingLeft * 2, height: textContainer.size.height)
         }
     }
     

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -74,6 +74,8 @@ final class CustomTextView: UITextView {
             print("didiSet: \(font)")
             placeholderLabel.font = font
             adjustLabelToFit()
+            
+            contentSize.height = placeholderLabel.frame.height + textContainerInset.top + textContainerInset.bottom
         }
     }
     
@@ -92,6 +94,7 @@ final class CustomTextView: UITextView {
             
             placeholderLabel.frame.size.width = placeholderLabel.frame.width + (oldValue.left - textContainerInset.left) + (oldValue.right - textContainerInset.right)
             
+            contentSize.height = placeholderLabel.frame.height + textContainerInset.top + textContainerInset.bottom
         }
     }
     
@@ -101,9 +104,11 @@ final class CustomTextView: UITextView {
     // default is nil. string is drawn 70% gray
     @IBInspectable var placeholder: String? {
         didSet {
-            print("placeholder did set.")
+//            print("placeholder did set.")
             placeholderLabel.text = placeholder
             adjustLabelToFit()
+            
+            contentSize.height = placeholderLabel.frame.height + textContainerInset.top + textContainerInset.bottom
         }
     }
     

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -103,6 +103,7 @@ final class CustomTextView: UITextView {
     override var frame: CGRect {
         didSet {
             adjustLabelToFit()
+            contentSize.height = placeholderLabel.frame.height + textContainerInset.top + textContainerInset.bottom
         }
     }
     

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -47,7 +47,7 @@ class ViewController: UIViewController {
 //        textView.textAlignment = .center
         textView.layer.borderColor = UIColor.black.cgColor
         textView.layer.borderWidth = 1
-//        textView.font = .systemFont(ofSize: 22.0)
+        textView.font = .systemFont(ofSize: 22.0)
         textView.keyboardAppearance = .dark
         
         textView.placeholder = "Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda."

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -101,7 +101,7 @@ class ViewController: UIViewController {
         // textContainerInsetを変更
         if let text = insetTextField.text, let top = Int(text) {
             textView.textContainerInset.top = CGFloat(top)
-            textView.textContainerInset.left = CGFloat(top)
+            textView.textContainerInset.bottom = CGFloat(top)
         }
     }
     

--- a/CustomTextView/ViewController.swift
+++ b/CustomTextView/ViewController.swift
@@ -101,7 +101,8 @@ class ViewController: UIViewController {
         // textContainerInsetを変更
         if let text = insetTextField.text, let top = Int(text) {
             textView.textContainerInset.top = CGFloat(top)
-            textView.textContainerInset.bottom = CGFloat(top)
+            textView.textContainerInset.left = CGFloat(top)
+            textView.textContainerInset.right = CGFloat(top)
         }
     }
     


### PR DESCRIPTION
textView.textContainerInsetの`left`と`right`を変更した時、Labelが水平移動するだけで、textViewからはみ出してしまっていたので、Labelのwidthを変更されることでマージンを維持させました。

また、placeholderもスクロールできるように、contentSizeも操作するようにしました。