### PR TITLE
#21.1 storyboardでの生成時のplaceholderの初期化

### DIFF
--- a/CustomTextView/AnotherViewController.swift
+++ b/CustomTextView/AnotherViewController.swift
@@ -46,8 +46,6 @@ class AnotherViewController: UIViewController {
         textView.frame.origin = CGPoint(x: centerPositionX - width / 2, y: 100)
         textView.layer.borderColor = UIColor.black.cgColor
         textView.layer.borderWidth = 1
-//        textView.font = .systemFont(ofSize: 22.0)
-        textView.keyboardAppearance = .dark
         
         textView.customDelegate = self
         

--- a/CustomTextView/Base.lproj/Main.storyboard
+++ b/CustomTextView/Base.lproj/Main.storyboard
@@ -39,15 +39,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, " textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Izh-Cu-ulr" customClass="CustomTextView" customModule="CustomTextView" customModuleProvider="target">
-                                <rect key="frame" x="45" y="59" width="284" height="208"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Izh-Cu-ulr" customClass="CustomTextView" customModule="CustomTextView" customModuleProvider="target">
+                                <rect key="frame" x="45" y="59" width="109" height="256"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="placeholder">
-                                        <mutableString key="value">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</mutableString>
+                                        <mutableString key="value">ea commodo consequat. Duissoeu aute irure dolor in reprelaborum. Nam liber te conscient to factor tum poen legum henderit in voluptate velit esse cillum dolore eu fugiatcon sectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut  nulla pariatur. Lorem ipsum dolor sit er elit lamet, aliquip exExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est  odioque civiuda.</mutableString>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </textView>
@@ -60,7 +60,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="i9I-qn-a71" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="692" y="36"/>
+            <point key="canvasLocation" x="692" y="35.532233883058474"/>
         </scene>
     </scenes>
 </document>

--- a/CustomTextView/CustomTextView.swift
+++ b/CustomTextView/CustomTextView.swift
@@ -87,6 +87,12 @@ final class CustomTextView: UITextView {
         }
     }
     
+    override var frame: CGRect {
+        didSet {
+            adjustLabelToFit()
+        }
+    }
+    
     
     // MARK: - public properties -
     
@@ -96,6 +102,7 @@ final class CustomTextView: UITextView {
             print("placeholder did set.")
             placeholderLabel.text = placeholder
             adjustLabelToFit()
+            print("adjustLabelToFit()")
         }
     }
     


### PR DESCRIPTION
`textView.frame`をコードで変更すると、`Label.frame`は変更されなかったために、`placeholder`のレイアウトがうまくいっていないことに気づいたので`frame`をoverrideすることで対応しました。

```swift
    override var frame: CGRect {
        didSet {
            adjustLabelToFit()
        }
    }
```